### PR TITLE
Fix padding of end of buffer character

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1139,7 +1139,7 @@ func (m Model) View() string {
 		displayLine++
 
 		if m.ShowLineNumbers {
-			lineNumber := m.style.EndOfBuffer.Render((fmt.Sprintf(m.lineNumberFormat, string(m.EndOfBufferCharacter))))
+			lineNumber := m.style.EndOfBuffer.Render(string(m.EndOfBufferCharacter))
 			s.WriteString(lineNumber)
 		}
 		s.WriteRune('\n')
@@ -1193,7 +1193,7 @@ func (m Model) placeholderView() string {
 		s.WriteString(prompt)
 
 		if m.ShowLineNumbers {
-			eob := m.style.EndOfBuffer.Render((fmt.Sprintf(m.lineNumberFormat, string(m.EndOfBufferCharacter))))
+			eob := m.style.EndOfBuffer.Render(string(m.EndOfBufferCharacter))
 			s.WriteString(eob)
 		}
 	}

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -429,11 +429,11 @@ func TestView(t *testing.T) {
 			name: "placeholder",
 			expected: heredoc.Doc(`
 				>   1 Hello, World!
-				>   ~
-				>   ~
-				>   ~
-				>   ~
-				>   ~
+				> ~
+				> ~
+				> ~
+				> ~
+				> ~
 			`),
 		},
 		{
@@ -445,11 +445,11 @@ func TestView(t *testing.T) {
 			},
 			expected: heredoc.Doc(`
 				>   1 the first line
-				>   ~
-				>   ~
-				>   ~
-				>   ~
-				>   ~
+				> ~
+				> ~
+				> ~
+				> ~
+				> ~
 			`),
 		},
 		{
@@ -463,9 +463,9 @@ func TestView(t *testing.T) {
 				>   1 the first line
 				>   2 the second line
 				>   3 the third line
-				>   ~
-				>   ~
-				>   ~
+				> ~
+				> ~
+				> ~
 			`),
 		},
 		{
@@ -512,11 +512,11 @@ func TestView(t *testing.T) {
 			},
 			expected: heredoc.Doc(`
 				>   1 the first line
-				>   *
-				>   *
-				>   *
-				>   *
-				>   *
+				> *
+				> *
+				> *
+				> *
+				> *
 			`),
 		},
 		{
@@ -531,9 +531,9 @@ func TestView(t *testing.T) {
 				>   1 the first line
 				>   2 the second line
 				>   3 the third line
-				>   *
-				>   *
-				>   *
+				> *
+				> *
+				> *
 			`),
 		},
 		{
@@ -582,11 +582,11 @@ func TestView(t *testing.T) {
 			},
 			expected: heredoc.Doc(`
 				*   1 the first line
-				*   ~
-				*   ~
-				*   ~
-				*   ~
-				*   ~
+				* ~
+				* ~
+				* ~
+				* ~
+				* ~
 			`),
 		},
 		{
@@ -601,9 +601,9 @@ func TestView(t *testing.T) {
 				*   1 the first line
 				*   2 the second line
 				*   3 the third line
-				*   ~
-				*   ~
-				*   ~
+				* ~
+				* ~
+				* ~
 			`),
 		},
 	}


### PR DESCRIPTION
The textarea component is incorrectly rendering the end of buffer character when line numbers are enabled. Line number padding was still being applied when displaying lines after the contents had been rendered. This resulted in the following output:

```text
>   1 the first line
>   2 the second line
>   3 the third line
>   ~
>   ~
```

The correct functionality is based on how Vim renders this text which should be as follows:

```text
>   1 the first line
>   2 the second line
>   3 the third line
> ~
> ~
```